### PR TITLE
18 PATCH /api/comments/:comment_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -501,7 +501,63 @@ describe('DELETE /api/comments/comment_id', () => {
         expect(msg).toBe('Not Found');
       });
   });
+  test('404: Responds with an error message if attempting to fetch deleted comment_id', () => {
+    return db.query('DELETE FROM comments WHERE comment_id = 2;')
+      .then(() => {
+        return request(app)
+          .get('/api/comments/2')
+          .expect(404)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe('Not Found');
+          });
+      })
+  })
 });
+
+describe.only('PATCH /api/comments/:comment_id', () => {
+  test('200: Responds with comment including updated vote property for given comment_id', () => {
+    const testBody = { inc_votes: 1 };
+
+    return request(app)
+      .patch('/api/comments/1')
+      .send(testBody)
+      .expect(200)
+      .then(({ body: { comment } }) => {
+        expect(comment).toEqual({
+          comment_id: 1,
+          body: "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!",
+          article_id: 9,
+          author: 'butter_bridge',
+          votes: 17,
+          created_at: '2020-04-06T12:17:00.000Z',
+        });
+      });
+  });
+  test('200: Responds with comment including updated vote count, value can be negative', () => {
+    const testBody = { inc_votes: -100 };
+
+    return request(app)
+      .patch('/api/comments/2')
+      .send(testBody)
+      .expect(200)
+      .then(({ body: { comment } }) => {
+        expect(comment).toEqual({
+          article_id: 1,
+          author: 'butter_bridge',
+          body: 'The beautiful thing about treasure is that it exists. Got to find out what kind of sheets these are; not cotton, not rayon, silky.',
+          comment_id: 2,
+          created_at: '2020-10-31T03:03:00.000Z',
+          votes: -86,
+        });
+      });
+  });
+  // test('400: Responds with an error message if comment_id is NaN', () => {});
+  // test('400: Responds with an error message if request body is empty object', () => {});
+  // test('400: Responds with an error message if request key is not inc_votes', () => {});
+  // test('400: Responds with an error message if request value is NaN', () => {});
+  // test("404: Responds with an error message if comment_id doesn't exist", () => {});
+});
+
 
 describe('GET /api/users', () => {
   test('200: Responds with an array of users containing correct properties', () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -502,19 +502,18 @@ describe('DELETE /api/comments/comment_id', () => {
       });
   });
   test('404: Responds with an error message if attempting to fetch deleted comment_id', () => {
-    return db.query('DELETE FROM comments WHERE comment_id = 2;')
-      .then(() => {
-        return request(app)
-          .get('/api/comments/2')
-          .expect(404)
-          .then(({ body: { msg } }) => {
-            expect(msg).toBe('Not Found');
-          });
-      })
-  })
+    return db.query('DELETE FROM comments WHERE comment_id = 2;').then(() => {
+      return request(app)
+        .get('/api/comments/2')
+        .expect(404)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe('Not Found');
+        });
+    });
+  });
 });
 
-describe.only('PATCH /api/comments/:comment_id', () => {
+describe('PATCH /api/comments/:comment_id', () => {
   test('200: Responds with comment including updated vote property for given comment_id', () => {
     const testBody = { inc_votes: 1 };
 
@@ -551,13 +550,62 @@ describe.only('PATCH /api/comments/:comment_id', () => {
         });
       });
   });
-  // test('400: Responds with an error message if comment_id is NaN', () => {});
-  // test('400: Responds with an error message if request body is empty object', () => {});
-  // test('400: Responds with an error message if request key is not inc_votes', () => {});
-  // test('400: Responds with an error message if request value is NaN', () => {});
-  // test("404: Responds with an error message if comment_id doesn't exist", () => {});
-});
+  test('400: Responds with an error message if comment_id is NaN', () => {
+    const testBody = { inc_votes: 5 };
 
+    return request(app)
+      .patch('/api/comments/brb-upvoting-my-own-posts')
+      .send(testBody)
+      .expect(400)
+      .then(({ body: { msg } }) => {
+        expect(msg).toBe('Bad Request');
+      });
+  });
+  test('400: Responds with an error message if request body is empty object', () => {
+    const testBody = {};
+
+    return request(app)
+      .patch('/api/comments/4')
+      .send(testBody)
+      .expect(400)
+      .then(({ body: { msg } }) => {
+        expect(msg).toBe('Bad Request');
+      });
+  });
+  test('400: Responds with an error message if request key is not inc_votes', () => {
+    const testBody = { change_votes_by_this_number: 5 };
+
+    return request(app)
+      .patch('/api/comments/5')
+      .send(testBody)
+      .expect(400)
+      .then(({ body: { msg } }) => {
+        expect(msg).toBe('Bad Request');
+      });
+  });
+  test('400: Responds with an error message if request value is NaN', () => {
+    const testBody = { inc_votes: 'one-hundred-votes' };
+
+    return request(app)
+      .patch('/api/comments/6')
+      .send(testBody)
+      .expect(400)
+      .then(({ body: { msg } }) => {
+        expect(msg).toBe('Bad Request');
+      });
+  });
+  test("404: Responds with an error message if comment_id doesn't exist", () => {
+    const testBody = { inc_votes: 10 };
+
+    return request(app)
+      .patch('/api/comments/99999')
+      .send(testBody)
+      .expect(404)
+      .then(({ body: { msg } }) => {
+        expect(msg).toBe('Not Found');
+      });
+  });
+});
 
 describe('GET /api/users', () => {
   test('200: Responds with an array of users containing correct properties', () => {

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -26,7 +26,7 @@ exports.getArticles = (req, res, next) => {
 exports.getArticleById = (req, res, next) => {
   const { article_id } = req.params;
 
-  fetchArticleById(article_id)
+  return fetchArticleById(article_id)
     .then((article) => {
       res.status(200).send({ article });
     })

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -8,7 +8,7 @@ exports.patchCommentById = (req, res, next) => {
   const { comment_id } = req.params;
   const { inc_votes } = req.body;
 
-  checkExists('comments', 'comment_id', comment_id)
+  return checkExists('comments', 'comment_id', comment_id)
     .then(() => {
       return updateCommentById(comment_id, inc_votes).then((comment) => {
         res.status(200).send({ comment });

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,5 +1,21 @@
 const { checkExists } = require('../db/seeds/utils');
-const { removeCommentById } = require('../models/comments.models');
+const {
+  updateCommentById,
+  removeCommentById,
+} = require('../models/comments.models');
+
+exports.patchCommentById = (req, res, next) => {
+  const { comment_id } = req.params;
+  const { inc_votes } = req.body;
+
+  checkExists('comments', 'comment_id', comment_id)
+    .then(() => {
+      return updateCommentById(comment_id, inc_votes).then((comment) => {
+        res.status(200).send({ comment });
+      });
+    })
+    .catch(next);
+};
 
 exports.deleteCommentById = (req, res, next) => {
   const { comment_id } = req.params;

--- a/db/errors/index.js
+++ b/db/errors/index.js
@@ -9,11 +9,17 @@ exports.customErrorHandler = (err, req, res, next) => {
 };
 
 exports.psqlErrorHandler = (err, req, res, next) => {
-  if (err.code === '22P02') {
-    res.status(400).send({ msg: 'Bad Request' });
-  } else if (err.code === '23503') {
-    res.status(404).send({ msg: 'Not Found' });
-  } next(err);
+  switch (err.code) {
+    case '22P02':
+      res.status(400).send({ msg: 'Bad Request' });
+      break;
+    case '23503':
+      res.status(404).send({ msg: 'Not Found' });
+      break;
+    default:
+      next(err);
+      break;
+  }
 };
 
 exports.serverErrorHandler = (err, req, res, next) => {

--- a/endpoints.json
+++ b/endpoints.json
@@ -224,6 +224,19 @@
       "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
     }
   },
+  "PATCH /api/comments/comment_id": {
+    "description": "removes the comment at a given comment_id",
+    "queries": [],
+    "exampleBody": { "inc_votes": 1 },
+    "exampleResponse": {
+      "comment_id": 1,
+      "body": "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!",
+      "article_id": 9,
+      "author": "butter_bridge",
+      "votes": 17,
+      "created_at": "2020-04-06T12:17:00.000Z"
+    }
+  },
   "DELETE /api/comments/comment_id": {
     "description": "removes the comment at a given comment_id",
     "queries": []

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -87,7 +87,7 @@ exports.updateArticleById = (article_id, inc_votes) => {
   }
 
   const queryString = `UPDATE articles
-  SET votes = $1
+  SET votes = votes + $1
   WHERE article_id = $2
   RETURNING *`;
 

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -1,5 +1,24 @@
 const db = require('../db/connection');
 
+exports.updateCommentById = (comment_id, inc_votes) => {
+  if (!inc_votes) {
+    return Promise.reject({
+      status: 400,
+      msg: `Bad Request`,
+    });
+  }
+
+  const queryString = `UPDATE comments
+  SET votes = votes + $1
+  WHERE comment_id = $2
+  RETURNING *`;
+
+  return db.query(queryString, [inc_votes, comment_id])
+    .then(({ rows }) => {
+    return rows[0];
+  });
+};
+
 exports.removeCommentById = (comment_id) => {
   return db.query(
     `DELETE FROM comments

--- a/routes/comments-router.js
+++ b/routes/comments-router.js
@@ -1,7 +1,13 @@
 const commentsRouter = require('express').Router();
 
-const { deleteCommentById } = require('../controllers/comments.controllers');
+const {
+  patchCommentById,
+  deleteCommentById,
+} = require('../controllers/comments.controllers');
 
-commentsRouter.delete('/:comment_id', deleteCommentById);
+commentsRouter
+  .route('/:comment_id')
+  .patch(patchCommentById)
+  .delete(deleteCommentById);
 
 module.exports = commentsRouter;


### PR DESCRIPTION
This PR includes:

- Implementation of PATCH endpoint for `/api/comments/:comment_id`
- Updated route for `users-router.js`
- Tests for core functionality and edge cases
- Update to `endpoints.JSON` reflecting new endpoint, including `exampleBody` and `exampleResponse` entries

It also includes a small update to the `DELETE /api/comments/:comment_id` endpoint, confirming that a deleted comment can no longer be fetched after deletion.